### PR TITLE
Fix data item template heading

### DIFF
--- a/admin/templates/partials/item.html.twig
+++ b/admin/templates/partials/item.html.twig
@@ -12,7 +12,7 @@
 {% endmacro %}
 
 <h1>
-    {{ config.plugins['data-manager'].types[type].item.title ?: type|e|capitalize ~ " " ~ "PLUGIN_DATA_MANAGER.ITEM_DETAILS"|e|tu }}
+    {{ config.plugins['data-manager'].types[type].name ?: type|e|capitalize ~ " " ~ "PLUGIN_DATA_MANAGER.ITEM_DETAILS"|e|tu }}
 </h1>
 <ul>
     {% if config.plugins['data-manager'].types[type].item.fields %}


### PR DESCRIPTION
The Twig value `config.plugins['data-manager'].types[type].item.title` isn't documented and is not consistent with the one used in `types.html.twig`.