### PR TITLE
Add item-read class to item link

### DIFF
--- a/admin/templates/partials/items.html.twig
+++ b/admin/templates/partials/items.html.twig
@@ -36,7 +36,7 @@
     {% else %}
         <ul class="">
             {{ dump(grav.twig.items) }}
-           {% for item in grav.twig.items %}
+           {% for item in grav.twig.items|sort|reverse %}
                <li class="">
                    <a href="{{ type }}/{{ item.route }}" class="page-edit item-read">{{ item.route|e }}</a>
                </li>

--- a/admin/templates/partials/items.html.twig
+++ b/admin/templates/partials/items.html.twig
@@ -38,7 +38,7 @@
            {% for item in grav.twig.items %}
                <li class="page-item">
                    <div class="row">
-                       <a href="{{ type }}/{{ item.route }}" class="page-edit">{{ item.route|e }}</a>
+                       <a href="{{ type }}/{{ item.route }}" class="page-edit item-read">{{ item.route|e }}</a>
                    </div>
                </li>
            {% endfor %}


### PR DESCRIPTION
To distinguish item details as viewed, the additional "item-read" class can be defined with a visited color of choice in a custom css as: 
#admin-main .admin-block a.item-read:visited {
    color: #f00000 !important;
    }