### PR TITLE
Allow CSV export even with list customization.

### DIFF
--- a/admin/templates/partials/items.html.twig
+++ b/admin/templates/partials/items.html.twig
@@ -41,8 +41,9 @@
                </li>
            {% endfor %}
         </ul>
-        <div class="button-bar danger">
-        <a href="{{ type }}.csv" class="button">Download as CSV</a>
-        </div>
     {% endif %}
+
+    <div class="button-bar danger">
+        <a href="{{ type }}.csv" class="button">Download as CSV</a>
+    </div>
 </div>


### PR DESCRIPTION
I couldn’t see a reason to hide the export button when customizing the list of entries, so here you go!