### PR TITLE
Filename does not need forward slash at the end...

### DIFF
--- a/data-manager.php
+++ b/data-manager.php
@@ -248,7 +248,7 @@ class DataManagerPlugin extends Plugin
         $tmp_file = uniqid() . '.csv';
         $tmp      = $tmp_dir . '/data-manager/' . basename($tmp_file);
 
-        $csv_file = File::instance($tmp . '/', $tmp_file);
+        $csv_file = File::instance($tmp);
         $csv_file->save($csv_data);
         Utils::download($csv_file->filename(), true);
         exit;


### PR DESCRIPTION
Remove unused second parameter from instance.

Export to CSV is not working. While creating instance $csv_file, the forward slash is added and a second unnecessary parameter is passed. 
$tmp defined on line 249, itself is the completely qualified path to file. It can be used as it is.

Bug reported on Stackoverflow -
https://stackoverflow.com/questions/71019105/i-trying-to-download-as-csv-from-grav-site-using-data-manager-but-getting-erro/71436625#71436625